### PR TITLE
Fix import statement in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Then use the component:
 </template>
 
 <script>
-import MonacoEditor from 'vue-monaco'
+import MonacoEditor from 'monaco-editor-vue3'
 
 export default {
   components: {


### PR DESCRIPTION
The name of the package is “monaco-editor-vue3” not  “vue-monaco”.