### PR TITLE
update deprecated beforeDestroy to beforeUnmount

### DIFF
--- a/src/MonacoEditor.vue
+++ b/src/MonacoEditor.vue
@@ -46,7 +46,7 @@ export default defineComponent({
   mounted() {
     this.initMonaco()
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.editor && this.editor.dispose()
   },
   methods: {


### PR DESCRIPTION
lifecycle method beforeDestroy has been renamed to beforeUnmount now in Vue3